### PR TITLE
Add transports, connection layer, and cleanup chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,26 @@
       "types": "./dist/bime.d.ts",
       "import": "./dist/bime.js",
       "require": "./dist/bime.cjs"
+    },
+    "./connection": {
+      "types": "./dist/connection.d.ts",
+      "import": "./dist/connection.js",
+      "require": "./dist/connection.cjs"
+    },
+    "./iframe": {
+      "types": "./dist/iframe.d.ts",
+      "import": "./dist/iframe.js",
+      "require": "./dist/iframe.cjs"
+    },
+    "./worker": {
+      "types": "./dist/worker.d.ts",
+      "import": "./dist/worker.js",
+      "require": "./dist/worker.cjs"
+    },
+    "./broadcast-channel": {
+      "types": "./dist/broadcast-channel.d.ts",
+      "import": "./dist/broadcast-channel.js",
+      "require": "./dist/broadcast-channel.cjs"
     }
   },
   "files": [
@@ -21,7 +41,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "bun build ./src/bime.ts --watch",
-    "build": "bun build ./src/bime.ts --outdir ./dist --entry-naming [name].js --sourcemap=external && bun build ./src/bime.ts --outdir ./dist --entry-naming [name].cjs --format cjs --sourcemap=external && tsc --emitDeclarationOnly --project tsconfig.build.json",
+    "build": "bun build ./src/bime.ts ./src/connection.ts ./src/iframe.ts ./src/worker.ts ./src/broadcast-channel.ts --outdir ./dist --entry-naming [name].js --sourcemap=external && bun build ./src/bime.ts ./src/connection.ts ./src/iframe.ts ./src/worker.ts ./src/broadcast-channel.ts --outdir ./dist --entry-naming [name].cjs --format cjs --sourcemap=external && tsc --emitDeclarationOnly --project tsconfig.build.json",
     "prepublishOnly": "bun run build",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",

--- a/src/bime.ts
+++ b/src/bime.ts
@@ -1,2 +1,7 @@
 export { default as invoke } from './invoke/invoke'
 export { default as listen } from './listen/listen'
+export type {
+  MessageListenerWithCleanup,
+  MessageSender,
+  Transport,
+} from './types'

--- a/src/broadcast-channel.ts
+++ b/src/broadcast-channel.ts
@@ -1,0 +1,1 @@
+export { broadcastChannelTransport } from './transports/broadcastChannel'

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,0 +1,1 @@
+export { createConnection } from './connection/createConnection'

--- a/src/connection/createConnection.test.ts
+++ b/src/connection/createConnection.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, jest, test } from 'bun:test'
+import { EventEmitter } from 'node:events'
+import { invoke, listen } from '../bime'
+import type { Transport } from '../types'
+import { createConnection } from './createConnection'
+
+/**
+ * Creates a pair of transports that simulate two sides communicating.
+ * Side A sends → Side B receives, and vice versa.
+ */
+function createTransportPair(): { a: Transport; b: Transport } {
+  const emitter = new EventEmitter()
+  const channelAtoB = crypto.randomUUID()
+  const channelBtoA = crypto.randomUUID()
+
+  const a: Transport = {
+    listener: (handler) => {
+      emitter.on(channelBtoA, handler)
+      return () => emitter.off(channelBtoA, handler)
+    },
+    sender: (message) => emitter.emit(channelAtoB, message),
+  }
+
+  const b: Transport = {
+    listener: (handler) => {
+      emitter.on(channelAtoB, handler)
+      return () => emitter.off(channelAtoB, handler)
+    },
+    sender: (message) => emitter.emit(channelBtoA, message),
+  }
+
+  return { a, b }
+}
+
+describe('createConnection', () => {
+  describe('handshake', () => {
+    test('establishes connection and flushes queued messages', async () => {
+      const { a, b } = createTransportPair()
+
+      const connA = createConnection(a, { synInterval: 10 })
+      // Queue a call before listen side is up
+      const model = { greet: (name: string) => `Hello ${name}` }
+
+      const api = invoke<typeof model>(connA)
+
+      // Start listen side with connection after a short delay
+      setTimeout(() => {
+        const connB = createConnection(b, { synInterval: 10 })
+        listen({ model, ...connB })
+      }, 50)
+
+      // This should queue and then resolve after handshake
+      const result = await api.greet('World')
+      expect(result).toEqual('Hello World')
+      connA.cleanup()
+    })
+
+    test('both sides connect when started simultaneously', async () => {
+      const { a, b } = createTransportPair()
+
+      const connA = createConnection(a, { synInterval: 10 })
+      const connB = createConnection(b, { synInterval: 10 })
+
+      const model = { sum: (a: number, b: number) => a + b }
+      listen({ model, ...connB })
+      const api = invoke<typeof model>(connA)
+
+      expect(await api.sum(1, 2)).toEqual(3)
+      connA.cleanup()
+      connB.cleanup()
+    })
+
+    test('timeout rejects queued calls', async () => {
+      const { a } = createTransportPair()
+
+      // No listen side — handshake will time out
+      const conn = createConnection(a, { timeout: 50, synInterval: 10 })
+      const model = { greet: (name: string) => `Hello ${name}` }
+      const api = invoke<typeof model>(conn)
+
+      await expect(api.greet('World')).rejects.toThrow('Connection timed out')
+      conn.cleanup()
+    })
+
+    test('configurable SYN interval', async () => {
+      const { a, b } = createTransportPair()
+      const senderSpy = jest.fn(a.sender)
+      const spiedA: Transport = { ...a, sender: senderSpy }
+
+      const conn = createConnection(spiedA, { synInterval: 20 })
+
+      // Wait for a few SYN messages
+      await new Promise((r) => setTimeout(r, 70))
+
+      // Should have sent multiple SYNs
+      expect(senderSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+      conn.cleanup()
+
+      // Connect the other side to avoid dangling
+      const connB = createConnection(b, { synInterval: 10 })
+      connB.cleanup()
+    })
+  })
+
+  describe('message ACKs and retry', () => {
+    test('retries unacknowledged messages', async () => {
+      const { a, b } = createTransportPair()
+
+      const connA = createConnection(a, {
+        synInterval: 10,
+        retry: { timeout: 20, tries: 3, backoff: 1 },
+      })
+      const connB = createConnection(b, { synInterval: 10 })
+
+      const callCount = jest.fn()
+      const model = {
+        greet: (name: string) => {
+          callCount()
+          return `Hello ${name}`
+        },
+      }
+
+      listen({ model, ...connB })
+      const api = invoke<typeof model>(connA)
+
+      const result = await api.greet('World')
+      expect(result).toEqual('Hello World')
+
+      connA.cleanup()
+      connB.cleanup()
+    })
+
+    test('rejects after max retries exhausted', async () => {
+      const { a, b } = createTransportPair()
+
+      // After handshake, drop ALL messages from B→A (responses + msg-acks)
+      let dropAll = false
+      const filteredA: Transport = {
+        listener: (handler) => {
+          return a.listener((msg) => {
+            if (dropAll) return
+            handler(msg)
+          })
+        },
+        sender: a.sender,
+      }
+
+      const connA = createConnection(filteredA, {
+        synInterval: 10,
+        retry: { timeout: 10, tries: 2, backoff: 1 },
+      })
+      const connB = createConnection(b, { synInterval: 10 })
+
+      const model = { greet: (name: string) => `Hello ${name}` }
+      listen({ model, ...connB })
+      const api = invoke<typeof model>(connA)
+
+      // Wait for handshake
+      await new Promise((r) => setTimeout(r, 50))
+
+      // Now drop everything from B→A
+      dropAll = true
+
+      await expect(api.greet('World')).rejects.toThrow(
+        'Message was not acknowledged after 2 retries',
+      )
+
+      connA.cleanup()
+      connB.cleanup()
+    })
+  })
+
+  describe('cleanup', () => {
+    test('cleanup chains to transport cleanup', () => {
+      const { a } = createTransportPair()
+      const transportCleanup = jest.fn()
+      const transportWithCleanup: Transport = {
+        ...a,
+        cleanup: transportCleanup,
+      }
+
+      const conn = createConnection(transportWithCleanup, { synInterval: 10 })
+      conn.cleanup()
+
+      expect(transportCleanup).toHaveBeenCalled()
+    })
+
+    test('invoke cleanup chains through connection to transport', () => {
+      const { a, b } = createTransportPair()
+      const transportCleanup = jest.fn()
+      const transportWithCleanup: Transport = {
+        ...a,
+        cleanup: transportCleanup,
+      }
+
+      const conn = createConnection(transportWithCleanup, { synInterval: 10 })
+      const model = { greet: (name: string) => `Hello ${name}` }
+      const api = invoke<typeof model>(conn)
+
+      api.cleanup()
+
+      expect(transportCleanup).toHaveBeenCalled()
+
+      const connB = createConnection(b, { synInterval: 10 })
+      connB.cleanup()
+    })
+
+    test('cleanup rejects queued messages', async () => {
+      const { a } = createTransportPair()
+
+      const conn = createConnection(a, { timeout: 5000, synInterval: 10 })
+      const model = { greet: (name: string) => `Hello ${name}` }
+      const api = invoke<typeof model>(conn)
+
+      const promise = api.greet('World')
+
+      // Cleanup before handshake completes
+      await new Promise((r) => setTimeout(r, 20))
+      conn.cleanup()
+
+      await expect(promise).rejects.toThrow()
+    })
+  })
+
+  describe('integration with bime', () => {
+    test('full stack: transport → connection → invoke/listen', async () => {
+      const { a, b } = createTransportPair()
+
+      const connA = createConnection(a, { synInterval: 10 })
+      const connB = createConnection(b, { synInterval: 10 })
+
+      const model = {
+        greet: (name: string) => `Hello ${name}`,
+        sum: (a: number, b: number) => a + b,
+        async fetchData(id: string) {
+          return { id, value: 42 }
+        },
+        willThrow() {
+          throw new Error('test error')
+        },
+      }
+
+      listen({ model, ...connB })
+      const api = invoke<typeof model>(connA)
+
+      expect(await api.greet('World')).toEqual('Hello World')
+      expect(await api.sum(1, 2)).toEqual(3)
+      expect(await api.fetchData('abc')).toEqual({ id: 'abc', value: 42 })
+      await expect(api.willThrow()).rejects.toThrow('test error')
+
+      connA.cleanup()
+      connB.cleanup()
+    })
+
+    test('concurrent calls through connection layer', async () => {
+      const { a, b } = createTransportPair()
+
+      const connA = createConnection(a, { synInterval: 10 })
+      const connB = createConnection(b, { synInterval: 10 })
+
+      const model = {
+        double: (n: number) => n * 2,
+        greet: (name: string) => `Hi ${name}`,
+      }
+
+      listen({ model, ...connB })
+      const api = invoke<typeof model>(connA)
+
+      const [x, y, z, w] = await Promise.all([
+        api.double(5),
+        api.greet('Alice'),
+        api.double(10),
+        api.greet('Bob'),
+      ])
+
+      expect(x).toEqual(10)
+      expect(y).toEqual('Hi Alice')
+      expect(z).toEqual(20)
+      expect(w).toEqual('Hi Bob')
+
+      connA.cleanup()
+      connB.cleanup()
+    })
+  })
+})

--- a/src/connection/createConnection.ts
+++ b/src/connection/createConnection.ts
@@ -1,0 +1,257 @@
+import superjson from 'superjson'
+import type { Transport } from '../types'
+
+type ConnectionOptions = {
+  timeout?: number
+  synInterval?: number
+  retry?: {
+    timeout?: number
+    tries?: number
+    backoff?: number
+  }
+}
+
+type PendingMessage = {
+  raw: string
+  id: string
+  acknowledged: boolean
+  retryTimer: ReturnType<typeof setTimeout> | null
+}
+
+type ControlMessage =
+  | { type: 'syn' }
+  | { type: 'ack' }
+  | { type: 'msg-ack'; id: string }
+
+const DEFAULTS = {
+  timeout: 3000,
+  synInterval: 100,
+  retry: {
+    timeout: 30,
+    tries: 3,
+    backoff: 3,
+  },
+} as const
+
+function hasType(value: unknown): value is { type: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof (value as { type: unknown }).type === 'string'
+  )
+}
+
+function hasId(value: unknown): value is { id: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof (value as { id: unknown }).id === 'string'
+  )
+}
+
+export function createConnection(
+  transport: Transport,
+  options?: ConnectionOptions,
+): Transport & { cleanup: () => void } {
+  const config = {
+    timeout: options?.timeout ?? DEFAULTS.timeout,
+    synInterval: options?.synInterval ?? DEFAULTS.synInterval,
+    retry: {
+      timeout: options?.retry?.timeout ?? DEFAULTS.retry.timeout,
+      tries: options?.retry?.tries ?? DEFAULTS.retry.tries,
+      backoff: options?.retry?.backoff ?? DEFAULTS.retry.backoff,
+    },
+  }
+
+  let connected = false
+  let cleanedUp = false
+  const queue: string[] = []
+  const pendingMessages = new Map<string, PendingMessage>()
+  let incomingHandler: ((message: string) => void) | null = null
+
+  // --- Handshake ---
+
+  const synInterval = setInterval(() => {
+    transport.sender(superjson.stringify({ type: 'syn' }))
+  }, config.synInterval)
+
+  const handshakeTimeout = setTimeout(() => {
+    if (connected) return
+    clearInterval(synInterval)
+    for (const raw of queue) {
+      rejectMessage(raw, 'Connection timed out')
+    }
+    queue.length = 0
+  }, config.timeout)
+
+  function onConnected() {
+    if (connected) return
+    connected = true
+    clearInterval(synInterval)
+    clearTimeout(handshakeTimeout)
+    for (const raw of queue) {
+      sendWithRetry(raw)
+    }
+    queue.length = 0
+  }
+
+  // --- Per-message ACK + retry ---
+
+  function extractMessageId(raw: string): string | null {
+    try {
+      const parsed: unknown = superjson.parse(raw)
+      if (hasId(parsed)) return parsed.id
+    } catch {
+      // not parseable — no id
+    }
+    return null
+  }
+
+  function sendWithRetry(raw: string) {
+    const id = extractMessageId(raw)
+    if (!id) {
+      transport.sender(raw)
+      return
+    }
+
+    const pending: PendingMessage = {
+      raw,
+      id,
+      acknowledged: false,
+      retryTimer: null,
+    }
+    pendingMessages.set(id, pending)
+    transport.sender(raw)
+    scheduleRetry(pending, config.retry.timeout, config.retry.tries)
+  }
+
+  function scheduleRetry(
+    pending: PendingMessage,
+    delay: number,
+    triesLeft: number,
+  ) {
+    pending.retryTimer = setTimeout(() => {
+      if (pending.acknowledged || cleanedUp) return
+
+      if (triesLeft > 0) {
+        transport.sender(pending.raw)
+        scheduleRetry(pending, delay * config.retry.backoff, triesLeft - 1)
+      } else {
+        pendingMessages.delete(pending.id)
+        rejectMessage(
+          pending.raw,
+          `Message was not acknowledged after ${config.retry.tries} retries`,
+        )
+      }
+    }, delay)
+  }
+
+  function rejectMessage(raw: string, errorMessage: string) {
+    const id = extractMessageId(raw)
+    if (!id || !incomingHandler) return
+
+    const errorResponse = superjson.stringify({
+      id,
+      type: 'error',
+      error: new Error(errorMessage),
+    })
+    incomingHandler(errorResponse)
+  }
+
+  // --- Control plane message handling ---
+
+  function isControlMessage(parsed: unknown): parsed is ControlMessage {
+    if (!hasType(parsed)) return false
+    return (
+      parsed.type === 'syn' ||
+      parsed.type === 'ack' ||
+      parsed.type === 'msg-ack'
+    )
+  }
+
+  function handleControlMessage(msg: ControlMessage) {
+    switch (msg.type) {
+      case 'syn':
+        transport.sender(superjson.stringify({ type: 'ack' }))
+        break
+      case 'ack':
+        onConnected()
+        break
+      case 'msg-ack': {
+        const pending = pendingMessages.get(msg.id)
+        if (pending) {
+          pending.acknowledged = true
+          if (pending.retryTimer) clearTimeout(pending.retryTimer)
+          pendingMessages.delete(msg.id)
+        }
+        break
+      }
+    }
+  }
+
+  // --- Wrapped listener/sender ---
+
+  const listenerCleanup = transport.listener((messageString: string) => {
+    try {
+      const parsed: unknown = superjson.parse(messageString)
+
+      if (isControlMessage(parsed)) {
+        handleControlMessage(parsed)
+        return
+      }
+
+      // Send msg-ack for incoming data messages with an id
+      if (hasId(parsed)) {
+        transport.sender(
+          superjson.stringify({ id: parsed.id, type: 'msg-ack' }),
+        )
+      }
+
+      // Forward to the application handler
+      incomingHandler?.(messageString)
+    } catch {
+      // Forward unparseable messages as-is (let the application layer handle them)
+      incomingHandler?.(messageString)
+    }
+  })
+
+  const listener: Transport['listener'] = (handler) => {
+    incomingHandler = handler
+    return () => {
+      incomingHandler = null
+    }
+  }
+
+  const sender: Transport['sender'] = (message) => {
+    if (cleanedUp) return
+    if (!connected) {
+      queue.push(message)
+      return
+    }
+    sendWithRetry(message)
+  }
+
+  const cleanup = () => {
+    if (cleanedUp) return
+    cleanedUp = true
+    clearInterval(synInterval)
+    clearTimeout(handshakeTimeout)
+
+    for (const pending of pendingMessages.values()) {
+      if (pending.retryTimer) clearTimeout(pending.retryTimer)
+    }
+    pendingMessages.clear()
+
+    for (const raw of queue) {
+      rejectMessage(raw, 'Connection was cleaned up')
+    }
+    queue.length = 0
+
+    listenerCleanup()
+    transport.cleanup?.()
+  }
+
+  return { listener, sender, cleanup }
+}

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,0 +1,1 @@
+export { iframeTransport } from './transports/iframe'

--- a/src/invoke/invoke.ts
+++ b/src/invoke/invoke.ts
@@ -1,6 +1,6 @@
 import superjson from 'superjson'
 import { z } from 'zod'
-import type { MessageListenerWithCleanup, MessageSender } from '../types'
+import type { Transport } from '../types'
 import SentMessageStore from './SentMessageStore'
 
 type MessageResponse<RemoteModel> = {
@@ -29,13 +29,8 @@ const responseMessageSchema = z.discriminatedUnion('type', [
 
 export default function invoke<
   Model extends Record<string, (...args: any[]) => any>,
->({
-  listener,
-  sender,
-}: {
-  listener: MessageListenerWithCleanup
-  sender: MessageSender
-}): Invoke<Model> {
+>(transport: Transport): Invoke<Model> {
+  const { listener, sender, cleanup: transportCleanup } = transport
   const sentMessagesStore = new SentMessageStore()
 
   let cleanedUp = false
@@ -83,6 +78,7 @@ export default function invoke<
     cleanedUp = true
     listenerCleanup()
     sentMessagesStore.clear()
+    transportCleanup?.()
   }
 
   const proxyHandler: ProxyHandler<object> = {

--- a/src/listen/listen.ts
+++ b/src/listen/listen.ts
@@ -1,6 +1,6 @@
 import superjson from 'superjson'
 import { z } from 'zod'
-import type { MessageListenerWithCleanup, MessageSender } from '../types'
+import type { MessageSender, Transport } from '../types'
 
 const invocationMessageSchema = z.object({
   id: z.string().min(1),
@@ -17,13 +17,11 @@ export default function listen<
   Model extends Record<string, (...args: any[]) => any>,
 >({
   model,
-  listener,
-  sender,
+  ...transport
 }: {
   model: Model
-  listener: MessageListenerWithCleanup
-  sender: MessageSender
-}): { cleanup: () => void } {
+} & Transport): { cleanup: () => void } {
+  const { listener, sender, cleanup: transportCleanup } = transport
   let cleanedUp = false
 
   if ('cleanup' in model) {
@@ -33,7 +31,7 @@ export default function listen<
   }
 
   const handler = callHandler(model, sender)
-  const cleanup = listener(handler)
+  const listenerCleanup = listener(handler)
 
   return {
     cleanup: () => {
@@ -41,7 +39,8 @@ export default function listen<
         throw new Error('The listener has been cleaned up.')
       }
       cleanedUp = true
-      cleanup()
+      listenerCleanup()
+      transportCleanup?.()
     },
   }
 }

--- a/src/transports/broadcastChannel.ts
+++ b/src/transports/broadcastChannel.ts
@@ -1,0 +1,20 @@
+import type { Transport } from '../types'
+
+export function broadcastChannelTransport(
+  channel: BroadcastChannel,
+): Transport {
+  const listener: Transport['listener'] = (handler) => {
+    const cb = (event: MessageEvent) => {
+      if (typeof event.data !== 'string') return
+      handler(event.data)
+    }
+    channel.addEventListener('message', cb)
+    return () => channel.removeEventListener('message', cb)
+  }
+
+  const sender: Transport['sender'] = (message) => {
+    channel.postMessage(message)
+  }
+
+  return { listener, sender }
+}

--- a/src/transports/iframe.ts
+++ b/src/transports/iframe.ts
@@ -1,0 +1,32 @@
+import type { Transport } from '../types'
+
+export function iframeTransport({
+  target,
+  origin,
+}: {
+  target: Window | HTMLIFrameElement
+  origin: string
+}): Transport {
+  const targetWindow =
+    target instanceof HTMLIFrameElement ? target.contentWindow : target
+
+  if (!targetWindow) {
+    throw new Error('iframe contentWindow is not available')
+  }
+
+  const listener: Transport['listener'] = (handler) => {
+    const cb = (event: MessageEvent) => {
+      if (event.origin !== origin) return
+      if (typeof event.data !== 'string') return
+      handler(event.data)
+    }
+    window.addEventListener('message', cb)
+    return () => window.removeEventListener('message', cb)
+  }
+
+  const sender: Transport['sender'] = (message) => {
+    targetWindow.postMessage(message, origin)
+  }
+
+  return { listener, sender }
+}

--- a/src/transports/worker.ts
+++ b/src/transports/worker.ts
@@ -1,0 +1,30 @@
+import type { Transport } from '../types'
+
+type MessageTarget = {
+  postMessage(message: unknown): void
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent) => void,
+  ): void
+  removeEventListener(
+    type: 'message',
+    listener: (event: MessageEvent) => void,
+  ): void
+}
+
+export function workerTransport(worker: MessageTarget): Transport {
+  const listener: Transport['listener'] = (handler) => {
+    const cb = (event: MessageEvent) => {
+      if (typeof event.data !== 'string') return
+      handler(event.data)
+    }
+    worker.addEventListener('message', cb)
+    return () => worker.removeEventListener('message', cb)
+  }
+
+  const sender: Transport['sender'] = (message) => {
+    worker.postMessage(message)
+  }
+
+  return { listener, sender }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,9 @@ export type MessageListenerWithCleanup = (
 ) => () => void
 
 export type MessageSender = (message: string) => void
+
+export type Transport = {
+  listener: MessageListenerWithCleanup
+  sender: MessageSender
+  cleanup?: () => void
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,1 @@
+export { workerTransport } from './transports/worker'


### PR DESCRIPTION
## Context
Adds a three-layer composable architecture for reliable message passing:

- **Transports** (iframe, worker, BroadcastChannel) — raw send/receive, each as a separate tree-shakable entry point
- **Connection layer** — SYN/ACK handshake, message queue until connected, per-message ACKs with auto-retry and exponential backoff
- **Cleanup chaining** — `api.cleanup()` tears down the whole stack automatically

Each layer produces the same `{ listener, sender }` interface (decorator pattern), so they compose naturally:
```ts
const api = invoke<Model>(createConnection(iframeTransport({ target: iframe, origin: "..." })))
```

- [x] Safe to roll back / revert?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added modular import entry points for iframe, Web Worker, and BroadcastChannel-based transports.
  * Introduced connection layer with handshake negotiation, message acknowledgment, automatic retry with backoff, and message queuing for improved reliability.
  * New unified Transport API for streamlined integration.

* **Tests**
  * Added comprehensive test suite covering connection handshake, message reliability, and error handling.

* **Chores**
  * Updated build configuration to support multiple entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->